### PR TITLE
유저 현재 위치를 기반으로한 미세먼지 예보 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,9 @@ out/
 /nbdist/
 /.nb-gradle/
 
+### application.yaml ###
+src/main/resources/application.yaml
+src/main/resources/application*.yaml
+
 ### VS Code ###
 .vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
 	// openFeign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.2'
+
+	// Json in Java
+	implementation group: 'org.json', name: 'json', version: '20240303'
 }
 dependencyManagement {
 	imports {

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,19 @@ dependencies {
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// openFeign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.2'
+}
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1" // 버전 확인
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/org/e2cho/e2cho_HW/E2choHwApplication.java
+++ b/src/main/java/org/e2cho/e2cho_HW/E2choHwApplication.java
@@ -2,7 +2,9 @@ package org.e2cho.e2cho_HW;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class E2choHwApplication {
 

--- a/src/main/java/org/e2cho/e2cho_HW/E2choHwApplication.java
+++ b/src/main/java/org/e2cho/e2cho_HW/E2choHwApplication.java
@@ -2,8 +2,10 @@ package org.e2cho.e2cho_HW;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableFeignClients // openFeign 사용 가능
 @EnableJpaAuditing
 @SpringBootApplication
 public class E2choHwApplication {

--- a/src/main/java/org/e2cho/e2cho_HW/config/DataGoKrClient.java
+++ b/src/main/java/org/e2cho/e2cho_HW/config/DataGoKrClient.java
@@ -1,0 +1,23 @@
+package org.e2cho.e2cho_HW.config;
+
+import org.e2cho.e2cho_HW.dto.weather.DataGoKr;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "DataGoKrClient",
+        url = "${dataGoKr-service.urls.base-url}",
+        configuration = DataGoKrClientConfig.class)
+public interface DataGoKrClient {
+
+    @GetMapping(headers = {"Content-Type=application/json"})
+    DataGoKr.Result getCurrentPM(
+            @RequestParam("serviceKey") String apiKey,
+            @RequestParam("returnType") String type,
+            @RequestParam("searchDate") String date,
+            @RequestParam("informCode") String code
+
+    );
+
+}

--- a/src/main/java/org/e2cho/e2cho_HW/config/DataGoKrClientConfig.java
+++ b/src/main/java/org/e2cho/e2cho_HW/config/DataGoKrClientConfig.java
@@ -1,0 +1,43 @@
+package org.e2cho.e2cho_HW.config;
+
+import feign.Logger;
+import feign.Request;
+import feign.Retryer;
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Indexed;
+
+@Configuration
+@ConfigurationProperties
+@Indexed
+@Data
+public class DataGoKrClientConfig {
+
+    @Value("${dataGoKr-service.http-client.read-timeout}")
+    private int readTimeout;
+
+    @Value("${dataGoKr-service.http-client.connect-timeout}")
+    private int connectTimeout;
+
+    @Value("${dataGoKr-service.api-key}")
+    private String apiKey;  // 여기에서 apiKey 값을 주입 받음
+
+
+    @Bean(name = "dataGoKrFeignOptions")
+    public Request.Options options() {
+        return new Request.Options(getConnectTimeout(), getReadTimeout());
+    }
+
+    @Bean(name = "dataGoKrFeignLogger")
+    public Logger.Level feignLogger() {
+        return Logger.Level.FULL;
+    }
+
+    @Bean(name = "dataGoKrFeignRetryer")
+    public Retryer retryer() {
+        return new Retryer.Default();
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/config/KakaoLocalClient.java
+++ b/src/main/java/org/e2cho/e2cho_HW/config/KakaoLocalClient.java
@@ -1,0 +1,17 @@
+package org.e2cho.e2cho_HW.config;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "KakaoLocalClient",
+        url = "${kakaoLocal-service.urls.base-url}",
+        configuration = KakaoLocalClientConfig.class)
+public interface KakaoLocalClient {
+
+    @GetMapping(headers = {"Content-Type=application/json"})
+    String getRegionByCoordinates(@RequestParam("x") double longitude,
+                                  @RequestParam("y") double latitude);
+
+}

--- a/src/main/java/org/e2cho/e2cho_HW/config/KakaoLocalClientConfig.java
+++ b/src/main/java/org/e2cho/e2cho_HW/config/KakaoLocalClientConfig.java
@@ -1,0 +1,49 @@
+package org.e2cho.e2cho_HW.config;
+
+import feign.Logger;
+import feign.Request;
+import feign.RequestInterceptor;
+import feign.Retryer;
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Indexed;
+
+@Configuration
+@ConfigurationProperties
+@Indexed
+@Data
+public class KakaoLocalClientConfig {
+
+    @Value("${kakaoLocal-service.http-client.read-timeout}")
+    private int readTimeout;
+
+    @Value("${kakaoLocal-service.http-client.connect-timeout}")
+    private int connectTimeout;
+
+    @Value("${kakaoLocal-service.api-key}")
+    private String apiKey;  // 여기에서 apiKey 값을 주입 받음
+
+
+    @Bean(name = "kakaoLocalFeignOptions")
+    public Request.Options options() {
+        return new Request.Options(getConnectTimeout(), getReadTimeout());
+    }
+
+    @Bean(name = "kakaoLocalFeignLogger")
+    public Logger.Level feignLogger() {
+        return Logger.Level.FULL;
+    }
+
+    @Bean(name = "kakaoLocalFeignRetryer")
+    public Retryer retryer() {
+        return new Retryer.Default();
+    }
+
+    @Bean
+    public RequestInterceptor apiKeyInterceptor() {
+        return request -> request.header("Authorization", "KakaoAK " + apiKey);
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/config/OpenWeatherMapClient.java
+++ b/src/main/java/org/e2cho/e2cho_HW/config/OpenWeatherMapClient.java
@@ -1,0 +1,22 @@
+package org.e2cho.e2cho_HW.config;
+
+import org.e2cho.e2cho_HW.dto.weather.OpenWeatherMap;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "OpenWeatherMapClient",
+        url = "${openWeatherMap-service.urls.base-url}",
+        configuration = OpenWeatherMapClientConfig.class)
+
+public interface OpenWeatherMapClient {
+
+        @GetMapping(value = "/weather", headers = "{Content-Type=application/json}")
+        OpenWeatherMap.Response getCurrentWeather(
+                @RequestParam("lat") double latitude,
+                @RequestParam("lon") double longitude,
+                @RequestParam("appid") String apiKey
+        );
+
+}

--- a/src/main/java/org/e2cho/e2cho_HW/config/OpenWeatherMapClientConfig.java
+++ b/src/main/java/org/e2cho/e2cho_HW/config/OpenWeatherMapClientConfig.java
@@ -1,0 +1,48 @@
+package org.e2cho.e2cho_HW.config;
+
+
+import feign.Logger;
+import feign.Request;
+import feign.Retryer;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Indexed;
+
+@Configuration
+@ConfigurationProperties
+@Indexed
+@Data
+@Slf4j
+public class OpenWeatherMapClientConfig {
+
+    @Value("${openWeatherMap-service.http-client.read-timeout}")
+    private int readTimeout;
+
+    @Value("${openWeatherMap-service.http-client.connect-timeout}")
+    private int connectTimeout;
+
+    @Value("${openWeatherMap-service.api-key}")
+    private String apiKey;  // 여기에서 apiKey 값을 주입 받음
+
+
+    @Bean
+    public Request.Options options() {
+        return new Request.Options(getConnectTimeout(), getReadTimeout());
+    }
+
+    @Bean
+    public Logger.Level feignLogger() {
+        return Logger.Level.FULL;
+    }
+
+    @Bean
+    public Retryer retryer() {
+        return new Retryer.Default();
+    }
+
+
+}

--- a/src/main/java/org/e2cho/e2cho_HW/constant/ErrorType.java
+++ b/src/main/java/org/e2cho/e2cho_HW/constant/ErrorType.java
@@ -1,0 +1,41 @@
+package org.e2cho.e2cho_HW.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorType {
+
+    // ----- Common ------
+    NotValidRequestError(
+            HttpStatus.BAD_REQUEST, "유효하지 않은 요청입니다."
+    ),
+    QueryParamTypeMismatchError(
+            HttpStatus.BAD_REQUEST, "해당 쿼리 파라미터의 타입이 올바르지 않습니다."
+    ),
+    MissingQueryParamError(
+            HttpStatus.BAD_REQUEST, "해당 파라미터의 값이 존재하지 않습니다.."
+    ),
+    AccessDeniedError(
+            HttpStatus.FORBIDDEN, "접근할 수 없는 권한을 가진 사용자입니다."
+    ),
+    InternalServerError(
+            HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생하였습니다. 문제가 지속되면 관리자에게 문의하세요."
+    ),
+
+
+    // ---- User ----
+    UserNotFoundError(
+            HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."
+    ),
+
+    // ----- Location ------
+    OutOfBoundaryError(
+            HttpStatus.BAD_REQUEST, "경위도가 범위(대한민국 내)를 벗어났습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/e2cho/e2cho_HW/constant/ErrorType.java
+++ b/src/main/java/org/e2cho/e2cho_HW/constant/ErrorType.java
@@ -34,6 +34,9 @@ public enum ErrorType {
     // ----- Location ------
     OutOfBoundaryError(
             HttpStatus.BAD_REQUEST, "경위도가 범위(대한민국 내)를 벗어났습니다."
+    ),
+    UserLocationInfoNotFoundError(
+            HttpStatus.NOT_FOUND, "유저는 존재하지만, 유저의 위치 정보가 존재하지 않습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/e2cho/e2cho_HW/constant/LocationBoundary.java
+++ b/src/main/java/org/e2cho/e2cho_HW/constant/LocationBoundary.java
@@ -1,0 +1,18 @@
+package org.e2cho.e2cho_HW.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum LocationBoundary {
+
+    EXTREME_EAST(131.87222222),
+    EXTREME_WEST(125.06666667),
+    EXTREME_NORTH(38.45000000),
+    EXTREME_SOUTH(33.10000000);
+
+    private final double coordinate;
+
+    LocationBoundary(double coordinate) {
+        this.coordinate = coordinate;
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/controller/user/UserController.java
+++ b/src/main/java/org/e2cho/e2cho_HW/controller/user/UserController.java
@@ -1,0 +1,30 @@
+package org.e2cho.e2cho_HW.controller.user;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.e2cho.e2cho_HW.dto.Registration;
+import org.e2cho.e2cho_HW.service.user.RegistrationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/registration")
+public class UserController {
+
+    private final RegistrationService registrationService;
+
+    @PostMapping()
+    public ResponseEntity<Registration.Response> userRegistration(
+            @Valid @RequestBody Registration.Request request
+    ) {
+
+        Registration.Dto dto = registrationService.userRegistration(request);
+
+        return new ResponseEntity<>(Registration.Response.createNewResponse(dto), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/controller/user/UserController.java
+++ b/src/main/java/org/e2cho/e2cho_HW/controller/user/UserController.java
@@ -2,7 +2,7 @@ package org.e2cho.e2cho_HW.controller.user;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.e2cho.e2cho_HW.dto.Registration;
+import org.e2cho.e2cho_HW.dto.user.Registration;
 import org.e2cho.e2cho_HW.service.user.RegistrationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/e2cho/e2cho_HW/controller/user/UserLocationController.java
+++ b/src/main/java/org/e2cho/e2cho_HW/controller/user/UserLocationController.java
@@ -1,0 +1,28 @@
+package org.e2cho.e2cho_HW.controller.user;
+
+
+import lombok.RequiredArgsConstructor;
+import org.e2cho.e2cho_HW.dto.user.Location;
+import org.e2cho.e2cho_HW.service.user.UserLocationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/location")
+public class UserLocationController {
+
+    private final UserLocationService userLocationService;
+
+    @PostMapping("/{id}/save")
+    public ResponseEntity<Location.Response> saveUserLocation(
+            @RequestBody Location.Request request,
+            @PathVariable("id") Long userId
+    ) {
+
+        Location.Dto dto = userLocationService.saveUserLocation(userId, request);
+
+        return new ResponseEntity<>(Location.Response.createNewResponse(dto), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/controller/weather/WeatherController.java
+++ b/src/main/java/org/e2cho/e2cho_HW/controller/weather/WeatherController.java
@@ -1,6 +1,7 @@
 package org.e2cho.e2cho_HW.controller.weather;
 
 import lombok.RequiredArgsConstructor;
+import org.e2cho.e2cho_HW.dto.weather.ParticulateMatter;
 import org.e2cho.e2cho_HW.dto.weather.Weather;
 import org.e2cho.e2cho_HW.service.weather.WeatherService;
 import org.springframework.http.HttpStatus;
@@ -24,5 +25,13 @@ public class WeatherController {
 
         return new ResponseEntity<>(Weather.Response.createNewResponse(dto), HttpStatus.OK);
 
+    }
+
+    @GetMapping("/{id}/currentPM")
+    public ResponseEntity<ParticulateMatter.Response> getCurrentPM(@PathVariable("id") Long userId){
+
+        ParticulateMatter.Dto dto = weatherService.getCurrentPM(userId);
+
+        return new ResponseEntity<>(ParticulateMatter.Response.createNewResponse(dto), HttpStatus.OK);
     }
 }

--- a/src/main/java/org/e2cho/e2cho_HW/controller/weather/WeatherController.java
+++ b/src/main/java/org/e2cho/e2cho_HW/controller/weather/WeatherController.java
@@ -1,0 +1,28 @@
+package org.e2cho.e2cho_HW.controller.weather;
+
+import lombok.RequiredArgsConstructor;
+import org.e2cho.e2cho_HW.dto.weather.Weather;
+import org.e2cho.e2cho_HW.service.weather.WeatherService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/weather")
+public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @GetMapping("/{id}/currentWeather")
+    public ResponseEntity<Weather.Response> getCurrentWeather(@PathVariable("id") Long userId){
+
+        Weather.Dto dto = weatherService.getCurrentWeather(userId);
+
+        return new ResponseEntity<>(Weather.Response.createNewResponse(dto), HttpStatus.OK);
+
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/domain/user/User.java
+++ b/src/main/java/org/e2cho/e2cho_HW/domain/user/User.java
@@ -3,7 +3,7 @@ package org.e2cho.e2cho_HW.domain.user;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.e2cho.e2cho_HW.dto.Registration;
+import org.e2cho.e2cho_HW.dto.user.Registration;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity

--- a/src/main/java/org/e2cho/e2cho_HW/domain/user/User.java
+++ b/src/main/java/org/e2cho/e2cho_HW/domain/user/User.java
@@ -1,0 +1,48 @@
+package org.e2cho.e2cho_HW.domain.user;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.e2cho.e2cho_HW.dto.Registration;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickname; // 사용자 닉네임
+
+    @Column(nullable = false)
+    private String birthdate; // 사용자 생일
+
+    @Builder
+    public User(
+            Long id,
+            String nickname,
+            String birthdate
+    ) {
+        this.id = id;
+        this.nickname = nickname;
+        this.birthdate = birthdate;
+    }
+
+    public static User registrationRequestToUser(
+            Registration.Request request
+    ) {
+
+        return User.builder()
+                .birthdate(request.getBirthdate())
+                .nickname(request.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/domain/user/UserLocation.java
+++ b/src/main/java/org/e2cho/e2cho_HW/domain/user/UserLocation.java
@@ -1,0 +1,74 @@
+package org.e2cho.e2cho_HW.domain.user;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.e2cho.e2cho_HW.dto.user.Location;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "userLocation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class UserLocation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "location_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private double latitude;
+
+    @Column(nullable = false)
+    private double longitude;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    // User 와의 관계 정의
+    @OneToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public UserLocation(double latitude, double longitude, LocalDateTime createdAt, LocalDateTime updatedAt, User user) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.user = user;
+    }
+
+    public static UserLocation fromRequestDto(
+            User user,
+            Location.Request request
+    ) {
+        return UserLocation.builder()
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .user(user)
+                .build();
+    }
+
+    public void update(Location.Request request){
+        this.latitude = request.getLatitude();
+        this.longitude = request.getLongitude();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}
+

--- a/src/main/java/org/e2cho/e2cho_HW/dto/Registration.java
+++ b/src/main/java/org/e2cho/e2cho_HW/dto/Registration.java
@@ -1,0 +1,70 @@
+package org.e2cho.e2cho_HW.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.e2cho.e2cho_HW.domain.user.User;
+
+public class Registration {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Request{
+
+        @NotBlank(message = "생년월일은 공백일 수 없습니다.")
+        @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "올바른 생년월일 형식은 yyyy-MM-dd 입니다.")
+        private String birthdate; // 생년월일
+
+        @NotBlank(message = "닉네임은 공백일 수 없습니다.")
+        @Size(max = 20, message = "닉네임은 최대 20자리까지 입력해주세요.")
+        private String nickname; // 닉네임
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Dto{
+
+        private Long id;
+
+        private String birthdate;
+
+        private String nickname;
+
+        public static Dto fromEntity(User user){
+            return Dto.builder()
+                    .id(user.getId())
+                    .birthdate(user.getBirthdate())
+                    .nickname(user.getNickname())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Response{
+
+        private Long id;
+
+        private String birthdate;
+
+        private String nickname;
+
+        public static Response createNewResponse(Dto dto){
+            return Response.builder()
+                    .id(dto.getId())
+                    .birthdate(dto.getBirthdate())
+                    .nickname(dto.getNickname())
+                    .build();
+
+        }
+
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/dto/user/Location.java
+++ b/src/main/java/org/e2cho/e2cho_HW/dto/user/Location.java
@@ -1,0 +1,80 @@
+package org.e2cho.e2cho_HW.dto.user;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.e2cho.e2cho_HW.domain.user.User;
+import org.e2cho.e2cho_HW.domain.user.UserLocation;
+
+import java.time.LocalDateTime;
+
+public class Location {
+
+
+    @Getter
+    @Setter
+    public static class Request{
+
+        @NotNull
+        private Double latitude;
+
+        @NotNull
+        private Double longitude;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Dto{
+
+        private String nickname; // 사용자 닉네임
+
+        private double latitude;
+
+        private double longitude;
+
+        private LocalDateTime createdAt;
+
+        private LocalDateTime updatedAt;
+
+        public static Dto of(User user, UserLocation userLocation){
+
+            return Dto.builder()
+                    .nickname(user.getNickname())
+                    .latitude(userLocation.getLatitude())
+                    .longitude(userLocation.getLongitude())
+                    .createdAt(userLocation.getCreatedAt())
+                    .updatedAt(userLocation.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Response{
+
+        private String nickname;
+
+        private double latitude;
+
+        private double longitude;
+
+        private LocalDateTime createdAt;
+
+        private LocalDateTime updatedAt;
+
+        public static Response createNewResponse(Dto dto){
+
+            return Response.builder()
+                    .nickname(dto.getNickname())
+                    .latitude(dto.getLatitude())
+                    .longitude(dto.getLongitude())
+                    .createdAt(dto.getCreatedAt())
+                    .updatedAt(dto.getUpdatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/dto/user/Registration.java
+++ b/src/main/java/org/e2cho/e2cho_HW/dto/user/Registration.java
@@ -1,4 +1,4 @@
-package org.e2cho.e2cho_HW.dto;
+package org.e2cho.e2cho_HW.dto.user;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/org/e2cho/e2cho_HW/dto/weather/DataGoKr.java
+++ b/src/main/java/org/e2cho/e2cho_HW/dto/weather/DataGoKr.java
@@ -1,0 +1,55 @@
+package org.e2cho.e2cho_HW.dto.weather;
+
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.List;
+
+
+public class DataGoKr {
+
+    @Data
+    public static class Result implements Serializable{
+
+        private Response response;
+
+        @Data
+        public static class Response implements Serializable{
+            private Body body;
+            private Header header;
+        }
+
+        @Data
+        public static class Header implements Serializable{
+            private String resultMsg;
+            private String resultCode;
+
+        }
+        @Data
+        public static class Body  implements Serializable{
+            private int totalCount;
+            private List<Item> items;
+            private int pageNo;
+            private int numOfRows;
+        }
+
+        @Data
+        public static class Item implements Serializable{
+            private String informCode;
+            private String informCause;
+            private String informOverall;
+            private String informData; // requestParam으로 넘긴 date와 비교
+            private String informGrade;
+            private String dataTime; // 최신 데이터 시간 확인
+            private String imageUrl1;
+            private String imageUrl2;
+            private String imageUrl3;
+            private String imageUrl4;
+            private String imageUrl5;
+            private String imageUrl6;
+
+        }
+
+
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/dto/weather/OpenWeatherMap.java
+++ b/src/main/java/org/e2cho/e2cho_HW/dto/weather/OpenWeatherMap.java
@@ -1,0 +1,72 @@
+package org.e2cho.e2cho_HW.dto.weather;
+
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class OpenWeatherMap {
+
+    @Data
+    public static class Response implements Serializable {
+        private Coord coord;
+        private List<Weather> weather;
+        private String base;
+        private Main main;
+        private int visibility;
+        private Wind wind;
+        private Clouds clouds;
+        private long dt;
+        private Sys sys;
+        private int timezone;
+        private long id;
+        private String name;
+        private int cod;
+    }
+
+    @Data
+    public static class Coord implements Serializable {
+        private double lon;
+        private double lat;
+    }
+
+    @Data
+    public static class Weather implements Serializable {
+        private int id;
+        private String main;
+        private String description;
+        private String icon;
+    }
+
+    @Data
+    public static class Main implements Serializable {
+        private double temp;
+        private double feels_like;
+        private double temp_min;
+        private double temp_max;
+        private int pressure;
+        private int humidity;
+        private int sea_level;
+        private int grnd_level;
+    }
+
+    @Data
+    public static class Wind implements Serializable {
+        private double speed;
+        private int deg;
+    }
+
+    @Data
+    public static class Clouds implements Serializable {
+        private int all;
+    }
+
+    @Data
+    public static class Sys implements Serializable {
+        private int type;
+        private long id;
+        private String country;
+        private long sunrise;
+        private long sunset;
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/dto/weather/ParticulateMatter.java
+++ b/src/main/java/org/e2cho/e2cho_HW/dto/weather/ParticulateMatter.java
@@ -1,0 +1,48 @@
+package org.e2cho.e2cho_HW.dto.weather;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ParticulateMatter {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Dto{
+
+        private String regionName; // 지역명
+
+        private String pmStatus; // 지역 미세먼지 등급
+
+        private String updatedTime; // 업데이트 시간
+
+        public static Dto of(String regionName, String pmStatus, String updatedTime){
+            return Dto.builder()
+                    .regionName(regionName)
+                    .pmStatus(pmStatus)
+                    .updatedTime(updatedTime)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Response{
+
+        private String regionName;
+
+        private String pmStatus;
+
+        private String updatedTime;
+
+        public static Response createNewResponse(Dto dto){
+            return Response.builder()
+                    .regionName(dto.getRegionName())
+                    .pmStatus(dto.getPmStatus())
+                    .updatedTime(dto.updatedTime)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/dto/weather/Weather.java
+++ b/src/main/java/org/e2cho/e2cho_HW/dto/weather/Weather.java
@@ -1,0 +1,227 @@
+package org.e2cho.e2cho_HW.dto.weather;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Weather {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Dto {
+
+        @NotNull
+        private Coord coord;
+
+        @NotNull
+        private List<WeatherDescription> weather;
+
+        @NotNull
+        private String base;
+
+        @NotNull
+        private Main main;
+
+        @NotNull
+        private int visibility;
+
+        @NotNull
+        private Wind wind;
+
+        @NotNull
+        private Clouds clouds;
+
+        @NotNull
+        private long dt;
+
+        @NotNull
+        private Sys sys;
+
+        @NotNull
+        private int timezone;
+
+        @NotNull
+        private long id;
+
+        @NotNull
+        private String name;
+
+        @NotNull
+        private int cod;
+
+        // fromOpenWeatherMap 메서드
+        public static Dto fromOpenWeatherMap(OpenWeatherMap.Response response) {
+            return Dto.builder()
+                    .coord(Coord.fromOpenWeatherMap(response.getCoord()))  // Coord 변환
+                    .weather(response.getWeather().stream()
+                            .map(WeatherDescription::fromOpenWeatherMap)
+                            .collect(Collectors.toList()))  // Weather 변환
+                    .base(response.getBase())
+                    .main(Main.fromOpenWeatherMap(response.getMain()))  // Main 변환
+                    .visibility(response.getVisibility())
+                    .wind(Wind.fromOpenWeatherMap(response.getWind()))  // Wind 변환
+                    .clouds(Clouds.fromOpenWeatherMap(response.getClouds()))  // Clouds 변환
+                    .dt(response.getDt())
+                    .sys(Sys.fromOpenWeatherMap(response.getSys()))  // Sys 변환
+                    .timezone(response.getTimezone())
+                    .id(response.getId())
+                    .name(response.getName())
+                    .cod(response.getCod())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private Coord coord;
+        private List<WeatherDescription> weather;
+        private String base;
+        private Main main;
+        private int visibility;
+        private Wind wind;
+        private Clouds clouds;
+        private long dt;
+        private Sys sys;
+        private int timezone;
+        private long id;
+        private String name;
+        private int cod;
+
+        // createNewResponse 메서드
+        public static Response createNewResponse(Dto dto) {
+            return Response.builder()
+                    .coord(dto.getCoord())
+                    .weather(dto.getWeather())
+                    .base(dto.getBase())
+                    .main(dto.getMain())
+                    .visibility(dto.getVisibility())
+                    .wind(dto.getWind())
+                    .clouds(dto.getClouds())
+                    .dt(dto.getDt())
+                    .sys(dto.getSys())
+                    .timezone(dto.getTimezone())
+                    .id(dto.getId())
+                    .name(dto.getName())
+                    .cod(dto.getCod())
+                    .build();
+        }
+    }
+
+    // 필요한 내부 클래스 정의 및 변환 메서드 추가
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Coord {
+        private double lon;
+        private double lat;
+
+        public static Coord fromOpenWeatherMap(OpenWeatherMap.Coord coord) {
+            return Coord.builder()
+                    .lon(coord.getLon())
+                    .lat(coord.getLat())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class WeatherDescription {
+        private int id;
+        private String main;
+        private String description;
+        private String icon;
+
+        public static WeatherDescription fromOpenWeatherMap(OpenWeatherMap.Weather weather) {
+            return WeatherDescription.builder()
+                    .id(weather.getId())
+                    .main(weather.getMain())
+                    .description(weather.getDescription())
+                    .icon(weather.getIcon())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Main {
+        private double temp;
+        private double feels_like;
+        private double temp_min;
+        private double temp_max;
+        private int pressure;
+        private int humidity;
+        private int sea_level;
+        private int grnd_level;
+
+        public static Main fromOpenWeatherMap(OpenWeatherMap.Main main) {
+            return Main.builder()
+                    .temp(main.getTemp())
+                    .feels_like(main.getFeels_like())
+                    .temp_min(main.getTemp_min())
+                    .temp_max(main.getTemp_max())
+                    .pressure(main.getPressure())
+                    .humidity(main.getHumidity())
+                    .sea_level(main.getSea_level())
+                    .grnd_level(main.getGrnd_level())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Wind {
+        private double speed;
+        private int deg;
+
+        public static Wind fromOpenWeatherMap(OpenWeatherMap.Wind wind) {
+            return Wind.builder()
+                    .speed(wind.getSpeed())
+                    .deg(wind.getDeg())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Clouds {
+        private int all;
+
+        public static Clouds fromOpenWeatherMap(OpenWeatherMap.Clouds clouds) {
+            return Clouds.builder()
+                    .all(clouds.getAll())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Sys {
+        private int type;
+        private long id;
+        private String country;
+        private long sunrise;
+        private long sunset;
+
+        public static Sys fromOpenWeatherMap(OpenWeatherMap.Sys sys) {
+            return Sys.builder()
+                    .type(sys.getType())
+                    .id(sys.getId())
+                    .country(sys.getCountry())
+                    .sunrise(sys.getSunrise())
+                    .sunset(sys.getSunset())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/exception/CustomErrorException.java
+++ b/src/main/java/org/e2cho/e2cho_HW/exception/CustomErrorException.java
@@ -1,0 +1,14 @@
+package org.e2cho.e2cho_HW.exception;
+
+import lombok.Getter;
+import org.e2cho.e2cho_HW.constant.ErrorType;
+
+@Getter
+public class CustomErrorException extends RuntimeException{
+    private final ErrorType errorType;
+    public CustomErrorException(ErrorType errorType){
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+
+}

--- a/src/main/java/org/e2cho/e2cho_HW/exception/CustomNotValidErrorException.java
+++ b/src/main/java/org/e2cho/e2cho_HW/exception/CustomNotValidErrorException.java
@@ -1,0 +1,12 @@
+package org.e2cho.e2cho_HW.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomNotValidErrorException extends RuntimeException {
+    private final String field;
+    public CustomNotValidErrorException(String field, String message) {
+        super(message);
+        this.field = field;
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/exception/ErrorResponseDto.java
+++ b/src/main/java/org/e2cho/e2cho_HW/exception/ErrorResponseDto.java
@@ -1,0 +1,30 @@
+package org.e2cho.e2cho_HW.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class ErrorResponseDto {
+
+    private String errorType;
+    private String message;
+
+    public static ErrorResponseDto fromException(CustomErrorException e){
+        return ErrorResponseDto.builder()
+                .errorType(e.getErrorType().name())
+                .message(e.getMessage())
+                .build();
+    }
+
+    public static ErrorResponseDto of(String errorType, String message){
+        return ErrorResponseDto.builder()
+                .errorType(errorType)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/exception/NotValidRequestErrorResponseDto.java
+++ b/src/main/java/org/e2cho/e2cho_HW/exception/NotValidRequestErrorResponseDto.java
@@ -1,0 +1,61 @@
+package org.e2cho.e2cho_HW.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.e2cho.e2cho_HW.constant.ErrorType;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class NotValidRequestErrorResponseDto {
+    private String errorType;
+    private String message;
+    private List<ErrorDescription> errorDescriptions;
+
+    public static NotValidRequestErrorResponseDto of(List<ErrorDescription> errorDescription){
+        return NotValidRequestErrorResponseDto.builder()
+                .errorType(ErrorType.NotValidRequestError.name())
+                .message(ErrorType.NotValidRequestError.getMessage())
+                .errorDescriptions(errorDescription)
+                .build();
+    }
+
+    public static NotValidRequestErrorResponseDto of(BindException e, List<ErrorDescription> errorDescription){
+        return NotValidRequestErrorResponseDto.builder()
+                .errorType(ErrorType.NotValidRequestError.name())
+                .message(ErrorType.NotValidRequestError.getMessage())
+                .errorDescriptions(errorDescription)
+                .build();
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @Builder
+    public static class ErrorDescription{
+        private String field;
+        private String message;
+
+        public static ErrorDescription of(String field, String message){
+            return ErrorDescription.builder()
+                    .field(field)
+                    .message(message)
+                    .build();
+        }
+
+
+        public static ErrorDescription of(FieldError error){
+            return ErrorDescription.builder()
+                    .field(error.getField())
+                    .message(error.getDefaultMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/e2cho/e2cho_HW/handler/GlobalExceptionHandler.java
@@ -1,0 +1,100 @@
+package org.e2cho.e2cho_HW.handler;
+
+import org.e2cho.e2cho_HW.constant.ErrorType;
+import org.e2cho.e2cho_HW.exception.CustomErrorException;
+import org.e2cho.e2cho_HW.exception.CustomNotValidErrorException;
+import org.e2cho.e2cho_HW.exception.ErrorResponseDto;
+import org.e2cho.e2cho_HW.exception.NotValidRequestErrorResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomErrorException.class)
+    public ResponseEntity<ErrorResponseDto> handleCustomErrorException(CustomErrorException ex) {
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.fromException(ex);
+        return new ResponseEntity<>(errorResponseDto, ex.getErrorType().getHttpStatus());
+    }
+
+    @ExceptionHandler(CustomNotValidErrorException.class)
+    protected ResponseEntity<NotValidRequestErrorResponseDto> handleCustomNotValidErrorException(CustomNotValidErrorException e) {
+        NotValidRequestErrorResponseDto notValidRequestErrorResponseDto =
+                NotValidRequestErrorResponseDto.of(
+                        List.of(NotValidRequestErrorResponseDto.ErrorDescription.of(e.getField(), e.getMessage()))
+                );
+
+        return new ResponseEntity<>(notValidRequestErrorResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<NotValidRequestErrorResponseDto> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        NotValidRequestErrorResponseDto.ErrorDescription errorDescription
+                = NotValidRequestErrorResponseDto.ErrorDescription.of( ErrorType.QueryParamTypeMismatchError.name(), ErrorType.QueryParamTypeMismatchError.getMessage());
+        List<NotValidRequestErrorResponseDto.ErrorDescription> ErrorDescriptions
+                = List.of(errorDescription);
+
+        NotValidRequestErrorResponseDto notValidRequestErrorResponseDto
+                = NotValidRequestErrorResponseDto.of(ErrorDescriptions);
+
+        return new ResponseEntity<>(notValidRequestErrorResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<NotValidRequestErrorResponseDto> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        NotValidRequestErrorResponseDto.ErrorDescription errorDescription
+                = NotValidRequestErrorResponseDto.ErrorDescription.of(ErrorType.MissingQueryParamError.name(), ErrorType.MissingQueryParamError.getMessage());
+        List<NotValidRequestErrorResponseDto.ErrorDescription> ErrorDescriptions
+                = List.of(errorDescription);
+
+        NotValidRequestErrorResponseDto notValidRequestErrorResponseDto
+                = NotValidRequestErrorResponseDto.of(ErrorDescriptions);
+
+        return new ResponseEntity<>(notValidRequestErrorResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponseDto> handleAccessDeniedException(AccessDeniedException e) {
+        ErrorResponseDto errorResponseDto =
+                ErrorResponseDto.of(
+                        ErrorType.AccessDeniedError.name(),
+                        ErrorType.AccessDeniedError.getMessage()
+                );
+
+        return new ResponseEntity<>(errorResponseDto, ErrorType.AccessDeniedError.getHttpStatus());
+    }
+
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<NotValidRequestErrorResponseDto> handleBindException(BindException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+
+        List<NotValidRequestErrorResponseDto.ErrorDescription> errorDescriptions =
+                fieldErrors.stream().map(NotValidRequestErrorResponseDto.ErrorDescription::of).toList();
+
+        NotValidRequestErrorResponseDto notValidRequestErrorResponseDto =
+                NotValidRequestErrorResponseDto.of(e, errorDescriptions);
+
+        return new ResponseEntity<>(notValidRequestErrorResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponseDto> HandleGeneralException(Exception e) {
+        ErrorResponseDto errorResponseDto =
+                ErrorResponseDto.of(
+                        ErrorType.InternalServerError.name(),
+                        ErrorType.InternalServerError.getMessage()
+                );
+
+        return new ResponseEntity<>(errorResponseDto, ErrorType.InternalServerError.getHttpStatus());
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/repository/user/UserLocationRepository.java
+++ b/src/main/java/org/e2cho/e2cho_HW/repository/user/UserLocationRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserLocationRepository extends JpaRepository<UserLocation, Long> {
 
     UserLocation findByUserId(Long userId);
+
 }

--- a/src/main/java/org/e2cho/e2cho_HW/repository/user/UserLocationRepository.java
+++ b/src/main/java/org/e2cho/e2cho_HW/repository/user/UserLocationRepository.java
@@ -1,0 +1,11 @@
+package org.e2cho.e2cho_HW.repository.user;
+
+import org.e2cho.e2cho_HW.domain.user.UserLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserLocationRepository extends JpaRepository<UserLocation, Long> {
+
+    UserLocation findByUserId(Long userId);
+}

--- a/src/main/java/org/e2cho/e2cho_HW/repository/user/UserRepository.java
+++ b/src/main/java/org/e2cho/e2cho_HW/repository/user/UserRepository.java
@@ -1,0 +1,8 @@
+package org.e2cho.e2cho_HW.repository.user;
+
+import org.e2cho.e2cho_HW.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/org/e2cho/e2cho_HW/repository/user/UserRepository.java
+++ b/src/main/java/org/e2cho/e2cho_HW/repository/user/UserRepository.java
@@ -3,6 +3,10 @@ package org.e2cho.e2cho_HW.repository.user;
 import org.e2cho.e2cho_HW.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findById(Long userId);
 
 }

--- a/src/main/java/org/e2cho/e2cho_HW/service/user/RegistrationService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/user/RegistrationService.java
@@ -1,0 +1,23 @@
+package org.e2cho.e2cho_HW.service.user;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.e2cho.e2cho_HW.domain.user.User;
+import org.e2cho.e2cho_HW.dto.Registration;
+import org.e2cho.e2cho_HW.repository.user.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegistrationService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Registration.Dto userRegistration(Registration.Request request){
+
+        User newUser = userRepository.save(User.registrationRequestToUser(request));
+
+        return Registration.Dto.fromEntity(newUser);
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/service/user/RegistrationService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/user/RegistrationService.java
@@ -3,7 +3,7 @@ package org.e2cho.e2cho_HW.service.user;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.e2cho.e2cho_HW.domain.user.User;
-import org.e2cho.e2cho_HW.dto.Registration;
+import org.e2cho.e2cho_HW.dto.user.Registration;
 import org.e2cho.e2cho_HW.repository.user.UserRepository;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/org/e2cho/e2cho_HW/service/user/UserLocationService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/user/UserLocationService.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 import static org.e2cho.e2cho_HW.constant.LocationBoundary.*;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserLocationService {

--- a/src/main/java/org/e2cho/e2cho_HW/service/user/UserLocationService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/user/UserLocationService.java
@@ -1,0 +1,57 @@
+package org.e2cho.e2cho_HW.service.user;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.e2cho.e2cho_HW.constant.ErrorType;
+import org.e2cho.e2cho_HW.domain.user.User;
+import org.e2cho.e2cho_HW.domain.user.UserLocation;
+import org.e2cho.e2cho_HW.dto.user.Location;
+import org.e2cho.e2cho_HW.exception.CustomErrorException;
+import org.e2cho.e2cho_HW.repository.user.UserLocationRepository;
+import org.e2cho.e2cho_HW.repository.user.UserRepository;
+import org.springframework.stereotype.Service;
+
+
+import java.util.Optional;
+
+import static org.e2cho.e2cho_HW.constant.LocationBoundary.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserLocationService {
+
+    private final UserRepository userRepository;
+    private final UserLocationRepository userLocationRepository;
+
+    @Transactional
+    public Location.Dto saveUserLocation(Long userId, Location.Request request){
+
+
+        // 1. 경로변수로 넘겨받은 userId를 가진 유저가 존재하는지 검증
+        User foundUser = userRepository.findById(userId)
+                .orElseThrow(()-> new CustomErrorException(ErrorType.UserNotFoundError));
+
+
+        // 2. request 로 받은 경위도 검사
+        if (!(EXTREME_SOUTH.getCoordinate() < request.getLatitude() && request.getLatitude() < EXTREME_NORTH.getCoordinate())
+                || !(EXTREME_WEST.getCoordinate() < request.getLongitude() && request.getLongitude() < EXTREME_EAST.getCoordinate())){
+
+            throw new CustomErrorException(ErrorType.OutOfBoundaryError);
+        }
+
+        // 3. 유저의 위치 정보가 이미 있다면, 경, 위도, 업데이트 시간 업데이트 없으면 처음 저장 로직 실행.
+        UserLocation foundUserLocation = userLocationRepository.findByUserId(foundUser.getId());
+
+        if (foundUserLocation != null){
+               foundUserLocation.update(request);
+
+        }else {
+            foundUserLocation = userLocationRepository.save(UserLocation.fromRequestDto(foundUser, request));
+        }
+
+        return Location.Dto.of(foundUser, foundUserLocation);
+    }
+
+}

--- a/src/main/java/org/e2cho/e2cho_HW/service/util/LocationUtilService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/util/LocationUtilService.java
@@ -1,0 +1,101 @@
+package org.e2cho.e2cho_HW.service.util;
+
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class LocationUtilService {
+
+    public String getCityName(String kakaoResponse){
+
+        JSONObject kakaoJsonObject = new JSONObject(kakaoResponse);
+
+        String cityName;
+
+        cityName = kakaoJsonObject.getJSONArray("documents")
+                .getJSONObject(0)
+                .getString("region_1depth_name");
+
+        return cityName;
+    }
+
+    public String getDistrictName(String kakaoResponse){
+
+        JSONObject kakaoJsonObject = new JSONObject(kakaoResponse);
+        String districtName;
+
+        districtName = kakaoJsonObject.getJSONArray("documents")
+                .getJSONObject(0)
+                .getString("region_2depth_name");
+
+        return districtName;
+    }
+
+
+    public String getConvertedCityName(String cityName, String districtName) {
+
+        String convertedCityName = null;
+
+        if (cityName.equals("경기도")) {
+            if (districtName.equals("수원시") || districtName.equals("용인시") || districtName.equals("화성시") ||
+                    districtName.equals("성남시") || districtName.equals("부천시") || districtName.equals("안산시") ||
+                    districtName.equals("평택시") || districtName.equals("안양시") || districtName.equals("시흥시") ||
+                    districtName.equals("김포시") || districtName.equals("광주시") || districtName.equals("하남시") ||
+                    districtName.equals("광명시") || districtName.equals("군포시") || districtName.equals("오산시") ||
+                    districtName.equals("이천시") || districtName.equals("안성시") || districtName.equals("의왕시") ||
+                    districtName.equals("양평군") || districtName.equals("여주시") || districtName.equals("과천시")) {
+                convertedCityName = "경기남부";
+            } else if (districtName.equals("고양시") || districtName.equals("남양주시") || districtName.equals("파주시") ||
+                    districtName.equals("의정부시") || districtName.equals("양주시") || districtName.equals("구리시") ||
+                    districtName.equals("포천시") || districtName.equals("동두천시") || districtName.equals("가평군") ||
+                    districtName.equals("연천군")) {
+                convertedCityName = "경기북부";
+            }
+        } else if (cityName.equals("강원특별자치도")) {
+
+            if (districtName.equals("강릉시") || districtName.equals("삼척시") || districtName.equals("동해시") ||
+                    districtName.equals("태백시") || districtName.equals("속초시") || districtName.equals("양양군") ||
+                    districtName.equals("고성군") || districtName.equals("통천군")) {
+                convertedCityName = "영동";
+
+            } else if (districtName.equals("철원군") || districtName.equals("화천군") || districtName.equals("양구군") ||
+                    districtName.equals("인제군") || districtName.equals("춘천시") || districtName.equals("홍천군") ||
+                    districtName.equals("횡성군") || districtName.equals("원주시") || districtName.equals("평창군") ||
+                    districtName.equals("영월군") || districtName.equals("정선군")) {
+                convertedCityName = "영서";
+            }
+        } else {
+
+            convertedCityName = convertRegionName(cityName);
+        }
+        return convertedCityName;
+    }
+
+    public String convertRegionName(String regionName) {
+        // 지역명 매핑을 위한 Map 생성
+        Map<String, String> regionMap = new HashMap<>();
+        regionMap.put("서울특별시", "서울");
+        regionMap.put("제주특별자치도", "제주");
+        regionMap.put("전라남도", "전남");
+        regionMap.put("전라북도", "전북");
+        regionMap.put("광주광역시", "광주");
+        regionMap.put("울산광역시", "울산");
+        regionMap.put("대구광역시", "대구");
+        regionMap.put("부산광역시", "부산");
+        regionMap.put("충청남도", "충남");
+        regionMap.put("충청북도", "충북");
+        regionMap.put("세종특별자치시", "세종");
+        regionMap.put("경상북도", "경북");
+        regionMap.put("경상남도", "경남");
+        regionMap.put("대전광역시", "대전");
+        regionMap.put("인천광역시", "인천");
+
+        // 매핑된 값이 있으면 반환, 없으면 원래 값 반환
+        return regionMap.getOrDefault(regionName, regionName);
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/service/weather/DataGoKrService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/weather/DataGoKrService.java
@@ -1,0 +1,19 @@
+package org.e2cho.e2cho_HW.service.weather;
+
+import lombok.RequiredArgsConstructor;
+import org.e2cho.e2cho_HW.config.DataGoKrClient;
+import org.e2cho.e2cho_HW.config.DataGoKrClientConfig;
+import org.e2cho.e2cho_HW.dto.weather.DataGoKr;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DataGoKrService {
+
+    private final DataGoKrClient dataGoKrClient;
+    private final DataGoKrClientConfig dataGoKrClientConfig;
+
+    public DataGoKr.Result getCurrentPM(String date){
+        return dataGoKrClient.getCurrentPM(dataGoKrClientConfig.getApiKey(), "json", date, "PM10");
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/service/weather/KakaoLocalService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/weather/KakaoLocalService.java
@@ -1,0 +1,16 @@
+package org.e2cho.e2cho_HW.service.weather;
+
+import lombok.RequiredArgsConstructor;
+import org.e2cho.e2cho_HW.config.KakaoLocalClient;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoLocalService {
+
+    private final KakaoLocalClient kakaoLocalClient;
+
+    public String getRegionByCoordinates(double latitude, double longitude){
+        return kakaoLocalClient.getRegionByCoordinates(longitude, latitude);
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/service/weather/OpenWeatherMapService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/weather/OpenWeatherMapService.java
@@ -1,0 +1,19 @@
+package org.e2cho.e2cho_HW.service.weather;
+
+import lombok.RequiredArgsConstructor;
+import org.e2cho.e2cho_HW.config.OpenWeatherMapClient;
+import org.e2cho.e2cho_HW.config.OpenWeatherMapClientConfig;
+import org.e2cho.e2cho_HW.dto.weather.OpenWeatherMap;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OpenWeatherMapService {
+
+    private final OpenWeatherMapClient openWeatherMapClient;
+    private final OpenWeatherMapClientConfig openWeatherMapClientConfig;
+
+    public OpenWeatherMap.Response getCurrentWeather(double latitude, double longitude){
+        return openWeatherMapClient.getCurrentWeather(latitude, longitude, openWeatherMapClientConfig.getApiKey());
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/service/weather/WeatherService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/weather/WeatherService.java
@@ -1,12 +1,23 @@
 package org.e2cho.e2cho_HW.service.weather;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.e2cho.e2cho_HW.domain.user.UserLocation;
+import org.e2cho.e2cho_HW.dto.weather.DataGoKr;
 import org.e2cho.e2cho_HW.dto.weather.OpenWeatherMap;
+import org.e2cho.e2cho_HW.dto.weather.ParticulateMatter;
 import org.e2cho.e2cho_HW.dto.weather.Weather;
 import org.e2cho.e2cho_HW.repository.user.UserLocationRepository;
+import org.e2cho.e2cho_HW.service.util.LocationUtilService;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class WeatherService {
@@ -14,6 +25,9 @@ public class WeatherService {
     private final UserLocationRepository userLocationRepository;
 
     private final OpenWeatherMapService openWeatherMapService;
+    private final KakaoLocalService kakaoLocalService;
+    private final DataGoKrService dataGoKrService;
+    private final LocationUtilService locationUtilService;
 
     public Weather.Dto getCurrentWeather(Long userId){
 
@@ -25,4 +39,65 @@ public class WeatherService {
 
         return Weather.Dto.fromOpenWeatherMap(currentWeather);
     }
+
+    public ParticulateMatter.Dto getCurrentPM(Long userId){
+
+        // 0. 현재 날짜
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd"));
+        String yesterday = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("YYYY-MM-dd"));
+
+        log.info("오늘 날짜 : {}", today);
+
+        // 1. 유저의 현재 위치 가져오기
+        UserLocation foundUserLocation = userLocationRepository.findByUserId(userId);
+
+        // 2. 경위도를 대한민국 행정구역으로 변환
+        String kakaoResponse = kakaoLocalService.getRegionByCoordinates(foundUserLocation.getLatitude(), foundUserLocation.getLongitude());
+
+        // 2-1. 응답에서 행정구역(시/도) 및 구역 정보 추출
+        String cityName = locationUtilService.getCityName(kakaoResponse);
+        String districtName = locationUtilService.getDistrictName(kakaoResponse);
+
+        // 2-2. 추출된 정보를 Data.Go.Kr 에서 조회한 정보와 상호작용할 수 있도록 준비
+        String convertedCityName = locationUtilService.getConvertedCityName(cityName, districtName);
+
+        // 3. 미세먼지 정보 조회
+        DataGoKr.Result currentPM = null;
+
+        if(LocalTime.now().isBefore(LocalTime.of(5,0))){
+             currentPM = dataGoKrService.getCurrentPM(yesterday);
+
+        } else {
+             currentPM = dataGoKrService.getCurrentPM(today);
+        }
+
+        // 3-1. 조회 결과 정보 업데이트 시간 확인
+        String updatedTime = currentPM.getResponse().getBody().getItems().get(0).getDataTime();
+
+        // 3-2. 조회 결과와 변환된 도시명과 일치하는 도시의 미세먼지 상태 구하기.
+        String informGrade = currentPM.getResponse().getBody().getItems().get(0).getInformGrade();
+        String pmStatus = getInformGradeForCity(informGrade, convertedCityName);
+
+
+
+        return ParticulateMatter.Dto.of(convertedCityName, pmStatus, updatedTime);
+
+    }
+
+    public String getInformGradeForCity(String informGrade, String cityName) {
+        // 도시와 상태 값을 분리하여 Map에 저장
+        Map<String, String> cityGradeMap = new HashMap<>();
+        String[] cityGrades = informGrade.split(",");
+
+        for (String cityGrade : cityGrades) {
+            String[] parts = cityGrade.split(" : ");
+            if (parts.length == 2) {
+                cityGradeMap.put(parts[0].trim(), parts[1].trim());
+            }
+        }
+
+        // 변환된 도시 이름에 대한 상태 값을 반환
+        return cityGradeMap.getOrDefault(cityName, "정보 없음");
+    }
+
 }

--- a/src/main/java/org/e2cho/e2cho_HW/service/weather/WeatherService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/weather/WeatherService.java
@@ -1,0 +1,28 @@
+package org.e2cho.e2cho_HW.service.weather;
+
+import lombok.RequiredArgsConstructor;
+import org.e2cho.e2cho_HW.domain.user.UserLocation;
+import org.e2cho.e2cho_HW.dto.weather.OpenWeatherMap;
+import org.e2cho.e2cho_HW.dto.weather.Weather;
+import org.e2cho.e2cho_HW.repository.user.UserLocationRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+
+    private final UserLocationRepository userLocationRepository;
+
+    private final OpenWeatherMapService openWeatherMapService;
+
+    public Weather.Dto getCurrentWeather(Long userId){
+
+        // 1. 유저의 현재 위치 가져오기
+        UserLocation foundUserLocation = userLocationRepository.findByUserId(userId);
+
+        // 2. 날씨 조회
+        OpenWeatherMap.Response currentWeather = openWeatherMapService.getCurrentWeather(foundUserLocation.getLatitude(), foundUserLocation.getLongitude());
+
+        return Weather.Dto.fromOpenWeatherMap(currentWeather);
+    }
+}

--- a/src/main/java/org/e2cho/e2cho_HW/service/weather/WeatherService.java
+++ b/src/main/java/org/e2cho/e2cho_HW/service/weather/WeatherService.java
@@ -42,12 +42,6 @@ public class WeatherService {
 
     public ParticulateMatter.Dto getCurrentPM(Long userId){
 
-        // 0. 현재 날짜
-        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd"));
-        String yesterday = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("YYYY-MM-dd"));
-
-        log.info("오늘 날짜 : {}", today);
-
         // 1. 유저의 현재 위치 가져오기
         UserLocation foundUserLocation = userLocationRepository.findByUserId(userId);
 
@@ -61,8 +55,12 @@ public class WeatherService {
         // 2-2. 추출된 정보를 Data.Go.Kr 에서 조회한 정보와 상호작용할 수 있도록 준비
         String convertedCityName = locationUtilService.getConvertedCityName(cityName, districtName);
 
-        // 3. 미세먼지 정보 조회
-        DataGoKr.Result currentPM = null;
+        // 3. 미세먼지 정보 조회 (새벽 5시 이전이라면 전날 데이터를 조회 => 전날 오후 11시에 발표된 미세먼지 예보 데이터를 가져옴. 즉 오후 11시 ~ 익일 새벽 5시 사이의 공백을 채울 수 있음.)
+        DataGoKr.Result currentPM;
+
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd"));
+
+        String yesterday = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("YYYY-MM-dd"));
 
         if(LocalTime.now().isBefore(LocalTime.of(5,0))){
              currentPM = dataGoKrService.getCurrentPM(yesterday);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=e2cho-HW


### PR DESCRIPTION
로직은 다음과 같습니다.

1. GET 요청시 넘겨받은 경로 변수로 유저의 현재 위치정보를 조회합니다.
2. 해당 경위도를 OpenFeign을 이용한 Kakao Local API를 통해 행정구역(시/도)를 비롯한 주소를 반환 받습니다.
3. 현재 날짜 및 시간을 구해서, 만약 새벽 5시 이전이면 전날 오후 11시에 발표된 미세먼지 예보 데이터를 OpenFeign을 이용하여 공공 데이터 포털의 API를 통해 가져옵니다. 새벽 5시 이후라면 당일 예보를 가져옵니다. 
4. 카카오 로컬 API를 통해 반환받은 행정구역명과 공공 데이터 포탈 API를 통해 가져온 데이터 내의 행정구역명이 다르기 때문에 메서드를 이용하여 맞추어 준 후, 유저의 현재 위치(행정구역)과 일치하는 미세먼지 예보 등급을 추출합니다. 
5.  결론으로 프론트엔드로 행정구역명,  미세먼지 예보 등급, 예보 업데이트 시간을 반환합니다. 

** 공공 데이터 포탈의 미세먼지 예보 데이터는 1일 4회(오전 5시, 오전 11시, 오후 5시, 오후 11시)에 업데이트 됩니다.

이슈번호 #10 